### PR TITLE
Add information about required polyfills/shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ initializeCustomElements(app, /* array of component names */);
 
 This will register custom elements for each of the component names you give to `initializeCustomElements` and will replace the custom element with your Glimmer component once the custom element connects. For example, if you provide the component name `'foo-bar'` you can now use the custom element `<foo-bar>` anywhere in the DOM and have your `foo-bar` component render in its place.
 
+## Browser Support
+
+Browser support for the `WebComponents` spec is not [not great yet](http://caniuse.com/#feat=custom-elementsv1).  If you want to use `customElements.define` where it is not yet supported natively, you'll need to install the [polyfill](https://github.com/webcomponents/custom-elements).
+
 ## License
 
 MIT License.


### PR DESCRIPTION
I tried the `--web-component` support just now and recognized the error I faced from other work with `customElement` that I've done recently. I figured that many people trying it might not be as familiar though, and that it was worth documenting.

The problem is that _no browser_ supports `customElement` with an ES5 class. Those with native support require a shim to with with Babel (or I guess, Typescript) output and those without native support require a full polyfill.  I've mentioned both here.

To make all of this much easier, I'm working on a pull request for for Polyfill.io that can allow developers to include a single URL that automatically pulls in only the required libraries for the browser making the request.  However, it's not finished yet; I will update these docs once it does.

https://github.com/Financial-Times/polyfill-service/pull/1101