### PR TITLE
Fix type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
     "Tom Dale <tom@tomdale.net>"
   ],
   "license": "MIT",
-  "dependencies": {
-    "@glimmer/application": "^0.3.6"
-  },
   "devDependencies": {
+    "@glimmer/application": "^0.4.0",
     "@glimmer/build": "^0.6.2",
     "ember-cli": "^2.12.1",
     "testem": "^1.15.0"


### PR DESCRIPTION
Addresses #9. @glimmer/application was being installed as a nested dependency because the blueprint installed @glimmer/application@0.4.0 and @glimmer/web-component@0.3.10:

```
$ npm ls @glimmer/application
hello-wc@0.0.0 /Users/rpitts/repos/personal/hello-wc
├── @glimmer/application@0.4.0
├─┬ @glimmer/component@0.3.9
│ └── @glimmer/application@0.3.10
└─┬ @glimmer/web-component@0.1.0
  └── @glimmer/application@0.3.10
```

This resulted in two different versions of `Environment` to be used, causing the type error.

This PR goes beyond upgrading @glimmer/application and moves it to `devDependencies`. We should not be seeing @glimmer/application inside `node_modules/@glimmer/web-component/node_modules` now.