### PR TITLE
ES5 compat

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,5 @@
 const build = require('@glimmer/build');
 
 module.exports = function() {
-  return build({
-    test: {
-      es5: false
-    }
-  });
+  return build();
 }

--- a/src/initialize-custom-elements.ts
+++ b/src/initialize-custom-elements.ts
@@ -7,17 +7,23 @@ export default function initializeCustomElements(app: Application, customElement
 }
 
 function initializeCustomElement(app: Application, name: string): void {
-  class GlimmerElement extends HTMLElement {
-    connectedCallback() {
-      let placeholder = document.createTextNode('');
-      let parent = this.parentNode;
-
-      parent.insertBefore(placeholder, this);
-      parent.removeChild(this);
-
-      app.renderComponent(name, parent, placeholder);
-    }
+  function GlimmerElement() {
+    return Reflect.construct(HTMLElement, [], GlimmerElement);
   }
+  GlimmerElement.prototype = Object.create(HTMLElement.prototype, {
+    constructor: { value: GlimmerElement },
+    connectedCallback: {
+      value: function connectedCallback() {
+        let placeholder = document.createTextNode('');
+        let parent = this.parentNode;
+
+        parent.insertBefore(placeholder, this);
+        parent.removeChild(this);
+
+        app.renderComponent(name, parent, placeholder);
+      }
+    }
+  });
 
   window.customElements.define(name, GlimmerElement);
 }


### PR DESCRIPTION
Next we can remove the babel bypass from @glimmer/application-pipeline! However, this change does work with ES2015 so this does not break anything.