### PR TITLE
Pass custom element attributes to Glimmer component element

### DIFF
--- a/src/initialize-custom-elements.ts
+++ b/src/initialize-custom-elements.ts
@@ -13,17 +13,32 @@ function initializeCustomElement(app: Application, name: string): void {
   GlimmerElement.prototype = Object.create(HTMLElement.prototype, {
     constructor: { value: GlimmerElement },
     connectedCallback: {
-      value: function connectedCallback() {
-        let placeholder = document.createTextNode('');
+      value: function connectedCallback(): void {
+        let placeholder = document.createElement('span');
         let parent = this.parentNode;
 
         parent.insertBefore(placeholder, this);
         parent.removeChild(this);
 
-        app.renderComponent(name, parent, placeholder);
+        app.renderComponent(name, parent, placeholder).then(() => {
+          let customElement = this as Element;
+          let glimmerElement = placeholder.previousElementSibling;
+
+          placeholder.remove();
+          assignAttributes(customElement, glimmerElement);
+        });
       }
     }
   });
 
   window.customElements.define(name, GlimmerElement);
+}
+
+function assignAttributes(fromElement: Element, toElement: Element): void {
+  let attributes = fromElement.attributes;
+
+  for (let i = 0; i < attributes.length; i++) {
+    let { name, value } = attributes.item(i);
+    toElement.setAttribute(name, value);
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "inlineSources": true,
     "inlineSourceMap": true,
     "noUnusedLocals": true,
+    "noImplicitAny": true,
     "declaration": true,
     "newLine": "LF",
     "outDir": "dist",


### PR DESCRIPTION
Requires https://github.com/glimmerjs/glimmer-application/pull/40. Intermediate step until we can have args and attrs passed into `renderComponent`.

Given a template like this:

```hbs
{{! cool-component.hbs }}
<div>
  <p>Hello Glimmer!</p>
</div>
```

And a custom element like this:

```html
<cool-component foo="bar"></cool-component>
```

We get this as the result:

```html
<div foo="bar">
  <p>Hello Glimmer!</p>
</div>
```