### PR TITLE
Add missing ()

### DIFF
--- a/src/initialize-custom-elements.ts
+++ b/src/initialize-custom-elements.ts
@@ -49,7 +49,7 @@ function assignAttributes(fromElement: Element, toElement: Element): void {
 
 function whenRendered(app, callback) {
   if (app['_rendering']) {
-    self.Promise.resolve.then(() => {
+    self.Promise.resolve().then(() => {
       whenRendered(app, callback);
     });
   } else {


### PR DESCRIPTION
Fixes https://github.com/glimmerjs/glimmer-web-component/issues/24 by adding a missing `()` for invocation.

TODO:

* [ ] Needs smoke testing. https://github.com/glimmerjs/glimmer-web-component/issues/24#issuecomment-341419218 implies this approach doesn't work, and https://github.com/glimmerjs/glimmer-web-component/pull/21#discussion_r138737677 claims it causes an infinite loop.